### PR TITLE
Posts index

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -13,15 +13,12 @@ import { AnimatedSocialIcon } from "react-animated-social-icons";
 const name = "Saakshaat Singh";
 export const siteTitle = "Saakshaat's Mind Dump";
 
-export default function Layout({ children, home }) {
+export default function Layout({ children, home, index }) {
   return (
     <div className={styles.container}>
       <Head>
         <link rel="icon" href="/favicon.ico" />
-        <meta
-          name="description"
-          content="Saakshaat's silly mind dump."
-        />
+        <meta name="description" content="Saakshaat's silly mind dump." />
         <meta
           property="og:image"
           content={`https://og-image.now.sh/${encodeURI(
@@ -40,6 +37,9 @@ export default function Layout({ children, home }) {
               alt={name}
             />
             <h1 className={utilStyles.heading2Xl}>{name}</h1>
+          </>
+        ) : index ? (
+          <>
           </>
         ) : (
           <>

--- a/pages/posts/index.js
+++ b/pages/posts/index.js
@@ -1,4 +1,45 @@
-export default function FirstPost() {
-    return <h1>Posts Index</h1>
-  }
-  
+import Head from "next/head";
+import Link from "next/link";
+
+import { getSortedPostsData } from "../../lib/posts";
+
+import Layout from "../../components/layout"
+
+import utilStyles from "../../styles/utils.module.css";
+
+export async function getStaticProps() {
+  const allPostsData = getSortedPostsData();
+
+  return {
+    props: {
+      allPostsData,
+    },
+  };
+}
+
+export default function FirstPost({ allPostsData }) {
+  return (
+    <Layout index>
+      <Head>
+        <title>Posts</title>
+      </Head>
+      <section className={`${utilStyles.headingMd} ${utilStyles.padding1px}`}>
+        <h2 className={utilStyles.heading2Xl}>Posts Index</h2>
+
+        <ul className={utilStyles.list}>
+          {allPostsData.map(({ id, title, date }) => (
+            <li className={utilStyles.listItem}>
+              <Link href={`/posts/${id}`}>
+                <a>{title}</a>
+              </Link>
+              <br />
+              <small className={utilStyles.lightText}>
+                <Date dateString={date} />
+              </small>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </Layout>
+  );
+}


### PR DESCRIPTION
Updates `Layout` component with a new prop for `index` for index pages. Index page layouts do not have the user's profile picture and name.

Updates the index page for the `/posts` route which now lists all posts.